### PR TITLE
Changes to move state to user's s3 bucket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= quay.io/scipian/terraform-controller:v0.0.2
+IMG ?= quay.io/scipian/terraform-controller:v0.0.3
 
 all: test manager
 

--- a/config/crds/terraform_v1alpha1_workspace.yaml
+++ b/config/crds/terraform_v1alpha1_workspace.yaml
@@ -22,6 +22,10 @@ spec:
           type: object
         spec:
           properties:
+            bucket:
+              type: string
+            dynamodbTable:
+              type: string
             envVars:
               type: object
             image:
@@ -38,6 +42,8 @@ spec:
           - image
           - secret
           - workingDir
+          - bucket
+          - dynamodbTable
           - region
           type: object
         status:

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: quay.io/scipian/terraform-controller:v0.0.2
+      - image: quay.io/scipian/terraform-controller:v0.0.3
         name: manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -5,15 +5,6 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: scipian
 ---
-kind: ConfigMap 
-apiVersion: v1 
-metadata:
-  name: scipian-config
-  namespace: scipian
-data:
-  state-bucket: cnqr-scipian-backend
-  state-locking: cnqr-scipian-backend-locking
----
 apiVersion: v1
 kind: Service
 metadata:
@@ -54,17 +45,6 @@ spec:
         - /root/manager
         image: controller:latest
         name: manager
-        env:
-          - name: SCIPIAN_STATE_BUCKET
-            valueFrom:
-              configMapKeyRef:
-                name: scipian-config
-                key: state-bucket
-          - name: SCIPIAN_STATE_LOCKING
-            valueFrom:
-              configMapKeyRef:
-                name: scipian-config
-                key: state-locking
         resources:
           limits:
             cpu: 100m

--- a/pkg/apis/terraform/v1alpha1/workspace_types.go
+++ b/pkg/apis/terraform/v1alpha1/workspace_types.go
@@ -27,12 +27,14 @@ import (
 type WorkspaceSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
-	Image      string            `json:"image"`
-	Secret     string            `json:"secret"`
-	WorkingDir string            `json:"workingDir"`
-	Region     string            `json:"region"`
-	EnvVars    map[string]string `json:"envVars,omitempty"`
-	TfVars     map[string]string `json:"tfVars,omitempty"`
+	Image         string            `json:"image"`
+	Secret        string            `json:"secret"`
+	WorkingDir    string            `json:"workingDir"`
+	Bucket        string            `json:"bucket"`
+	DynamoDBTable string            `json:"dynamodbTable"`
+	Region        string            `json:"region"`
+	EnvVars       map[string]string `json:"envVars,omitempty"`
+	TfVars        map[string]string `json:"tfVars,omitempty"`
 }
 
 // WorkspaceStatus defines the observed state of Workspace

--- a/pkg/terraform/configmap.go
+++ b/pkg/terraform/configmap.go
@@ -2,7 +2,6 @@ package terraform
 
 import (
 	"fmt"
-	"os"
 
 	terraformv1alpha1 "github.com/scipian/terraform-controller/pkg/apis/terraform/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -12,11 +11,8 @@ import (
 // CreateConfigMap creates a Kubernetes Configmap with variables that the Terraform Job will reference
 // +kubebuilder:rbac:groups=core,resources=configmaps;secrets;pods;pods/volumes,verbs=get;list;watch;create;update;patch;delete
 func CreateConfigMap(name string, namespace string, ws *terraformv1alpha1.Workspace) *corev1.ConfigMap {
-	scipianBucket := os.Getenv("SCIPIAN_STATE_BUCKET")
-	scipianStateLocking := os.Getenv("SCIPIAN_STATE_LOCKING")
-
-	backendTF := formatBackendTerraform(scipianBucket, scipianStateLocking, ws)
-	tfVars := formatTerraformVars(scipianBucket, ws)
+	backendTF := formatBackendTerraform(ws)
+	tfVars := formatTerraformVars(ws)
 
 	configMapData := make(map[string]string)
 	configMapData["backend-tf"] = backendTF
@@ -36,26 +32,22 @@ func CreateConfigMap(name string, namespace string, ws *terraformv1alpha1.Worksp
 	}
 }
 
-func formatBackendTerraform(bucket string, stateLocking string, ws *terraformv1alpha1.Workspace) string {
+func formatBackendTerraform(ws *terraformv1alpha1.Workspace) string {
 	var region string
-
-	if stateLocking == "" {
-		stateLocking = fmt.Sprintf("%s-locking", bucket)
-	}
 
 	if ws.Spec.Region == "cn-north-1" || ws.Spec.Region == "cn-northwest-1" {
 		region = "cn-north-1"
 	} else {
 		region = "us-west-2"
 	}
-	backend := fmt.Sprintf(BackendTemplate, bucket, region, stateLocking, ws.Namespace)
+	backend := fmt.Sprintf(BackendTemplate, ws.Spec.Bucket, region, ws.Spec.DynamoDBTable, ws.Namespace)
 	return backend
 }
 
-func formatTerraformVars(bucket string, ws *terraformv1alpha1.Workspace) string {
+func formatTerraformVars(ws *terraformv1alpha1.Workspace) string {
 	var terraformVariables, variable string
 	var namespaceVariable = fmt.Sprintf(`network_workspace_namespace = "%s"`, ws.Namespace)
-	var stateBucket = fmt.Sprintf(`state_bucket_name = "%s"`, bucket)
+	var stateBucket = fmt.Sprintf(`state_bucket_name = "%s"`, ws.Spec.Bucket)
 	terraformVariables = terraformVariables + namespaceVariable + "\n"
 	terraformVariables = terraformVariables + stateBucket + "\n"
 

--- a/pkg/terraform/configmap_test.go
+++ b/pkg/terraform/configmap_test.go
@@ -17,8 +17,10 @@ var testWorkspaceBackend = terraformv1alpha1.Workspace{
 		Namespace: "namespace",
 	},
 	Spec: terraformv1alpha1.WorkspaceSpec{
-		Region: "us-west-2",
-		TfVars: map[string]string{"foo": "bar"},
+		Region:        "us-west-2",
+		Bucket:        "test-backend",
+		DynamoDBTable: "test-locking",
+		TfVars:        map[string]string{"foo": "bar"},
 	},
 }
 
@@ -69,12 +71,12 @@ func TestCreateConfigMap(t *testing.T) {
 	defer os.Setenv("SCIPIAN_STATE_LOCKING", tempLocking)
 
 	// Test formatBackendTerraform function
-	g.Expect(formatBackendTerraform("test-backend", "test-locking", ws)).Should(gomega.Equal(testBackend))
-	g.Expect(formatBackendTerraform("test-backend", "test-locking", ws)).NotTo(gomega.BeEmpty())
+	g.Expect(formatBackendTerraform(ws)).Should(gomega.Equal(testBackend))
+	g.Expect(formatBackendTerraform(ws)).NotTo(gomega.BeEmpty())
 
 	// Test formatTerraformVars function
-	g.Expect(formatTerraformVars("test-backend", ws)).Should(gomega.Equal(testTfVars))
-	g.Expect(formatTerraformVars("test-backend", ws)).NotTo(gomega.BeEmpty())
+	g.Expect(formatTerraformVars(ws)).Should(gomega.Equal(testTfVars))
+	g.Expect(formatTerraformVars(ws)).NotTo(gomega.BeEmpty())
 
 	// Test CreatConfigMap function
 	configMap := CreateConfigMap("foo", "bar", ws)


### PR DESCRIPTION
  - Scipian no longer will manage state in it's own backend, rather
    in a user's specified s3 bucket in their account.

Signed-off-by: nicklathe <n.lathe@sap.com>