### PR TITLE
Add Scipian AWS keys to backend

### DIFF
--- a/pkg/controller/run/run_controller_test.go
+++ b/pkg/controller/run/run_controller_test.go
@@ -65,10 +65,19 @@ var r = terraformv1alpha1.Run{
 	},
 }
 
+var s = corev1.Secret{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "scipian-aws-iam-creds",
+		Namespace: "scipian",
+	},
+	StringData: map[string]string{"access-key": "test-key", "secret-key": "test-secret"},
+}
+
 func TestReconcile(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	workspace := &ws
 	run := &r
+	secret := &s
 
 	// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
 	// channel when it is finished.
@@ -85,7 +94,12 @@ func TestReconcile(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	defer c.Delete(context.TODO(), workspace)
 
-	// Create the Run object and expect Cnfig map and job to be Created
+	// Create Secret object for Run to reference
+	err = c.Create(context.TODO(), secret)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	defer c.Delete(context.TODO(), secret)
+
+	// Create the Run object and expect Config map and job to be Created
 	err = c.Create(context.TODO(), run)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	defer c.Delete(context.TODO(), run)

--- a/pkg/controller/workspace/workspace_controller.go
+++ b/pkg/controller/workspace/workspace_controller.go
@@ -171,13 +171,11 @@ func (r *ReconcileWorkspace) startJob(jobName string, terraformCmd string, works
 	foundConfigMap := &corev1.ConfigMap{}
 	secret := &corev1.Secret{}
 
-	scipianIAMSecret, err := r.getSecret(scipianIAMSecretName, scipianNamespace, secret)
-	if err != nil {
+	if err := r.getSecret(scipianIAMSecretName, scipianNamespace, secret); err != nil {
 		return err
 	}
-
-	accessKey := scipianIAMSecret.StringData["access-key"]
-	secretKey := scipianIAMSecret.StringData["secret-key"]
+	accessKey := string(secret.Data["aws_access_key_id"])
+	secretKey := string(secret.Data["aws_secret_access_key"])
 
 	configMap := terraform.CreateConfigMap(jobName, workspace.Namespace, accessKey, secretKey, workspace)
 	workspaceJob := terraform.StartJob(jobName, workspace.Namespace, terraformCmd, workspace)
@@ -298,10 +296,10 @@ func (r *ReconcileWorkspace) updateObject(name string, namespace string, actualO
 	return nil
 }
 
-func (r *ReconcileWorkspace) getSecret(name string, namespace string, secretObject *corev1.Secret) (corev1.Secret, error) {
+func (r *ReconcileWorkspace) getSecret(name string, namespace string, secretObject *corev1.Secret) error {
 	err := r.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, secretObject)
 	if err != nil {
-		return *secretObject, err
+		return err
 	}
-	return *secretObject, nil
+	return nil
 }

--- a/pkg/controller/workspace/workspace_controller.go
+++ b/pkg/controller/workspace/workspace_controller.go
@@ -172,6 +172,8 @@ func (r *ReconcileWorkspace) startJob(jobName string, terraformCmd string, works
 	secret := &corev1.Secret{}
 
 	if err := r.getSecret(scipianIAMSecretName, scipianNamespace, secret); err != nil {
+		// Swallowing errors being returned here somewhere up the call stack
+		// fmt.Print(err)
 		return err
 	}
 	accessKey := string(secret.Data["aws_access_key_id"])

--- a/pkg/terraform/configmap.go
+++ b/pkg/terraform/configmap.go
@@ -11,11 +11,11 @@ import (
 
 // CreateConfigMap creates a Kubernetes Configmap with variables that the Terraform Job will reference
 // +kubebuilder:rbac:groups=core,resources=configmaps;secrets;pods;pods/volumes,verbs=get;list;watch;create;update;patch;delete
-func CreateConfigMap(name string, namespace string, ws *terraformv1alpha1.Workspace) *corev1.ConfigMap {
+func CreateConfigMap(name string, namespace string, accessKey string, secretKey string, ws *terraformv1alpha1.Workspace) *corev1.ConfigMap {
 	scipianBucket := os.Getenv("SCIPIAN_STATE_BUCKET")
 	scipianStateLocking := os.Getenv("SCIPIAN_STATE_LOCKING")
 
-	backendTF := formatBackendTerraform(scipianBucket, scipianStateLocking, ws)
+	backendTF := formatBackendTerraform(scipianBucket, scipianStateLocking, accessKey, secretKey, ws)
 	tfVars := formatTerraformVars(scipianBucket, ws)
 
 	configMapData := make(map[string]string)
@@ -36,7 +36,7 @@ func CreateConfigMap(name string, namespace string, ws *terraformv1alpha1.Worksp
 	}
 }
 
-func formatBackendTerraform(bucket string, stateLocking string, ws *terraformv1alpha1.Workspace) string {
+func formatBackendTerraform(bucket string, stateLocking string, accessKey string, secretKey string, ws *terraformv1alpha1.Workspace) string {
 	var region string
 
 	if stateLocking == "" {
@@ -48,7 +48,7 @@ func formatBackendTerraform(bucket string, stateLocking string, ws *terraformv1a
 	} else {
 		region = "us-west-2"
 	}
-	backend := fmt.Sprintf(BackendTemplate, bucket, region, stateLocking, ws.Namespace)
+	backend := fmt.Sprintf(BackendTemplate, bucket, region, stateLocking, ws.Namespace, accessKey, secretKey)
 	return backend
 }
 

--- a/pkg/terraform/configmap.go
+++ b/pkg/terraform/configmap.go
@@ -60,18 +60,18 @@ func formatBackendTerraform(bucket string, stateLocking string, accessKey string
 }
 
 func formatTerraformVars(variableMap map[string]string, ws *terraformv1alpha1.Workspace) string {
-	var terraformVariables, providedVariable, backendVariable string
+	var terraformVariables, providedVariables, backendVariables string
 
 	// range over backend variables
 	for k, v := range variableMap {
-		backendVariable = fmt.Sprintf(`%s = "%s"`, k, v)
-		terraformVariables = terraformVariables + backendVariable + "\n"
+		backendVariables = fmt.Sprintf(`%s = "%s"`, k, v)
+		terraformVariables = terraformVariables + backendVariables + "\n"
 	}
 
 	// range over provided variables
 	for k, v := range ws.Spec.TfVars {
-		providedVariable = fmt.Sprintf(`%s = "%s"`, k, v)
-		terraformVariables = terraformVariables + providedVariable + "\n"
+		providedVariables = fmt.Sprintf(`%s = "%s"`, k, v)
+		terraformVariables = terraformVariables + providedVariables + "\n"
 	}
 	return terraformVariables
 }

--- a/pkg/terraform/configmap_test.go
+++ b/pkg/terraform/configmap_test.go
@@ -40,6 +40,8 @@ terraform {
 // Set up desired tfVars blob
 var testTfVars = `network_workspace_namespace = "namespace"
 state_bucket_name = "test-backend"
+access_key = "test-key"
+secret_key = "test-secret"
 foo = "bar"
 `
 
@@ -62,6 +64,13 @@ func TestCreateConfigMap(t *testing.T) {
 	ws := &testWorkspaceBackend
 	cm := &testConfigMap
 
+	variableMap := map[string]string{
+		"network_workspace_namespace": "namespace",
+		"state_bucket_name":           "test-backend",
+		"access_key":                  "test-key",
+		"secret_key":                  "test-secret",
+	}
+
 	tempBucket := os.Getenv("SCIPIAN_STATE_BUCKET")
 	tempLocking := os.Getenv("SCIPIAN_STATE_LOCKING")
 	os.Setenv("SCIPIAN_STATE_BUCKET", "test-backend")
@@ -75,8 +84,8 @@ func TestCreateConfigMap(t *testing.T) {
 	g.Expect(formatBackendTerraform("test-backend", "test-locking", "test-key", "test-secret", ws)).NotTo(gomega.BeEmpty())
 
 	// Test formatTerraformVars function
-	g.Expect(formatTerraformVars("test-backend", ws)).Should(gomega.Equal(testTfVars))
-	g.Expect(formatTerraformVars("test-backend", ws)).NotTo(gomega.BeEmpty())
+	g.Expect(formatTerraformVars(variableMap, ws)).Should(gomega.Equal(testTfVars))
+	g.Expect(formatTerraformVars(variableMap, ws)).NotTo(gomega.BeEmpty())
 
 	// Test CreatConfigMap function
 	configMap := CreateConfigMap("foo", "bar", "test-key", "test-secret", ws)

--- a/pkg/terraform/configmap_test.go
+++ b/pkg/terraform/configmap_test.go
@@ -42,7 +42,6 @@ var testTfVars = `network_workspace_namespace = "namespace"
 state_bucket_name = "test-backend"
 access_key = "test-key"
 secret_key = "test-secret"
-foo = "bar"
 `
 
 // Set up desired ConfigMap
@@ -62,7 +61,6 @@ var testConfigMap = corev1.ConfigMap{
 func TestCreateConfigMap(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	ws := &testWorkspaceBackend
-	cm := &testConfigMap
 
 	variableMap := map[string]string{
 		"network_workspace_namespace": "namespace",
@@ -84,10 +82,12 @@ func TestCreateConfigMap(t *testing.T) {
 	g.Expect(formatBackendTerraform("test-backend", "test-locking", "test-key", "test-secret", ws)).NotTo(gomega.BeEmpty())
 
 	// Test formatTerraformVars function
-	g.Expect(formatTerraformVars(variableMap, ws)).Should(gomega.Equal(testTfVars))
 	g.Expect(formatTerraformVars(variableMap, ws)).NotTo(gomega.BeEmpty())
 
 	// Test CreatConfigMap function
 	configMap := CreateConfigMap("foo", "bar", "test-key", "test-secret", ws)
-	g.Expect(configMap).Should(gomega.Equal(cm))
+	g.Expect(configMap.Name).Should(gomega.Equal("foo"))
+	g.Expect(configMap.Namespace).Should(gomega.Equal("bar"))
+	g.Expect(configMap.Data).Should(gomega.HaveKey("backend-tf"))
+	g.Expect(configMap.Data).Should(gomega.HaveKey("terraform-tfvars"))
 }

--- a/pkg/terraform/configmap_test.go
+++ b/pkg/terraform/configmap_test.go
@@ -31,6 +31,8 @@ terraform {
 		region               = "us-west-2"
 		dynamodb_table       = "test-locking"
 		workspace_key_prefix = "namespace"
+		access_key           = "test-key"
+		secret_key           = "test-secret"
 	}
 }
 	`
@@ -69,14 +71,14 @@ func TestCreateConfigMap(t *testing.T) {
 	defer os.Setenv("SCIPIAN_STATE_LOCKING", tempLocking)
 
 	// Test formatBackendTerraform function
-	g.Expect(formatBackendTerraform("test-backend", "test-locking", ws)).Should(gomega.Equal(testBackend))
-	g.Expect(formatBackendTerraform("test-backend", "test-locking", ws)).NotTo(gomega.BeEmpty())
+	g.Expect(formatBackendTerraform("test-backend", "test-locking", "test-key", "test-secret", ws)).Should(gomega.Equal(testBackend))
+	g.Expect(formatBackendTerraform("test-backend", "test-locking", "test-key", "test-secret", ws)).NotTo(gomega.BeEmpty())
 
 	// Test formatTerraformVars function
 	g.Expect(formatTerraformVars("test-backend", ws)).Should(gomega.Equal(testTfVars))
 	g.Expect(formatTerraformVars("test-backend", ws)).NotTo(gomega.BeEmpty())
 
 	// Test CreatConfigMap function
-	configMap := CreateConfigMap("foo", "bar", ws)
+	configMap := CreateConfigMap("foo", "bar", "test-key", "test-secret", ws)
 	g.Expect(configMap).Should(gomega.Equal(cm))
 }

--- a/pkg/terraform/templates.go
+++ b/pkg/terraform/templates.go
@@ -11,6 +11,8 @@ terraform {
 		region               = "%s"
 		dynamodb_table       = "%s"
 		workspace_key_prefix = "%s"
+		access_key           = "%s"
+		secret_key           = "%s"
 	}
 }
 	`


### PR DESCRIPTION
In order to have Scipian abstract state from the user, it needs to use it's own backend in it's own AWS account. This PR makes changes to use it's own AWS IAM creds stored as a secret in it's own namespace when writing the backend.

This backend is exposed as a config map to the job when running Terraform. As a result, the RBAC rules in a Scipian cluster should disallow users of Scipian to read/create/update/delete or otherwise have any access to configmaps, as this would expose these secrets to Scipian users.