### PR TITLE
Add additional cluster role and binding

### DIFF
--- a/config/rbac/k8s_types_role.yaml
+++ b/config/rbac/k8s_types_role.yaml
@@ -1,0 +1,36 @@
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    creationTimestamp: null
+    name: manager-role-k8s-types
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - pods/volumes
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+    

--- a/config/rbac/k8s_types_role_binding.yaml
+++ b/config/rbac/k8s_types_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding-k8s-types
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role-add
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: scipian

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,6 +1,8 @@
 resources:
 - role.yaml
 - role_binding.yaml
+- k8s_types_role.yaml
+- k8s_types_role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
 # Comment the following 3 lines if you want to disable


### PR DESCRIPTION
Add cluster role and role binding so controller can CRUD secrets, jobs, configmaps, pods, and volumes across cluster

