### PR TITLE
Fix cluster role name misreference in role binding

### DIFF
--- a/config/rbac/k8s_types_role_binding.yaml
+++ b/config/rbac/k8s_types_role_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role-add
+  name: manager-role-k8s-types
 subjects:
 - kind: ServiceAccount
   name: default


### PR DESCRIPTION
I missed renaming the cluster role name reference in the cluster role binding yaml to match correctly in last PR. This fixes that.