### PR TITLE
Iterate version number in manager.yaml

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -36,7 +36,7 @@ spec:
         - /manager
         args:
         - --enable-leader-election
-        image: quay.io/scipian/terraform-controller:v0.0.5
+        image: quay.io/scipian/terraform-controller:v0.0.6
         name: manager
         env:
           - name: SCIPIAN_STATE_BUCKET


### PR DESCRIPTION
Manager.yaml was pointing at a previous version, which deployed the wrong version of the terraform-controller.

